### PR TITLE
fixed typo on docker-compose

### DIFF
--- a/labs/lab03a/README.md
+++ b/labs/lab03a/README.md
@@ -211,7 +211,7 @@ services:
     restart: always
 ```
 
-When running Docker from the command line, we use `docker compose up` to build and run a composed service.  IntelliJ understands Docker compose files, so we don't have to worry.  We will modify our Travis CI file.
+When running Docker from the command line, we use `docker-compose up` to build and run a composed service.  IntelliJ understands Docker compose files, so we don't have to worry.  We will modify our Travis CI file.
 
 ### Test MySQL Connection
 


### PR DESCRIPTION
I believe docker-compose is actually another binary.
https://docs.docker.com/compose/reference/up/